### PR TITLE
comment links for authentification

### DIFF
--- a/views/partials/eligibility.ejs
+++ b/views/partials/eligibility.ejs
@@ -1,7 +1,7 @@
 <script type="text/javascript" src="/js/checkEmail.js"></script>
 <div class="fr-container">
     <div class="fr-grid-row fr-pb-6w" >
-      <div class="fr-col-6 separator fr-p-5w">
+      <div class="fr-col-6 fr-p-5w">
         <h2 class="fr-h4">Testez l'égibilité d'une adresse mail :</h2>
         <div class="fr-container fr-px-0">
           <div class="fr-grid-row">
@@ -28,18 +28,18 @@
           </div>
         </div>
       </div>
-      <% if (!user) { %>
-      <div class="fr-col-6 fr-p-5w">
+      <%# if (!user) { %>
+      <!-- <div class="fr-col-6 fr-p-5w">
         <h2 class="fr-h4">Découvrez le parcours utilisateur d'Authentification</h2>
         <a class="fr-link fr-link--lg" href="<%= loginUrl %>">Connexion avec Authentification</a>
-      </div>
-      <% } %>
-      <% if (user) { %>
-        <div class="fr-col-6 fr-p-5w">
+      </div> -->
+      <%# } %>
+      <%# if (user) { %>
+        <!-- <div class="fr-col-6 fr-p-5w">
           <p class="fr-mb-1w fr-h3">🎉 Authentification réussie 🎉</p>
           <p class="fr-mb-1w">Vous êtes actuellement connecté·e grâce à Authentification avec l'adresse mail <%= user %> ! </p>
-        </div>
-      <% } %>
+        </div> -->
+      <%# } %>
 
     </div>
   </div>

--- a/views/partials/menu.ejs
+++ b/views/partials/menu.ejs
@@ -31,8 +31,8 @@
                             <li>
                                 <a class="fr-link" href="/glossaire">Glossaire</a>
                             </li>
-                            <% if (user) { %>
-                            <li>
+                            <%# if (user) { %>
+                            <!-- <li>
                                 <span class="fr-link" href="">
                                     Connecté en tant que : <%= user %>
                                 </span>
@@ -41,12 +41,12 @@
                                 <a class="fr-link fr-icon-logout-box-r-fill" href="/logout">
                                     Déconnexion
                                 </a>
-                            </li>
-                            <% } else { %>
-                            <li>
+                            </li> -->
+                            <%# } else { %>
+                            <!-- <li>
                                 <a class="fr-link fr-link--lg" href="<%= loginUrl %>">Connexion avec Authentification</a>
-                            </li>
-                            <% } %>
+                            </li> -->
+                            <%# } %>
                         </ul>
                     </div>
                 </div>


### PR DESCRIPTION
En attendant la mise en prod de la dernière version du serveur authentification, je propose de supprimer les liens de connexions.
La fonctionnalité reste disponible via la route /login